### PR TITLE
Adding description tag to transactions.

### DIFF
--- a/django_bitcoin/models.py
+++ b/django_bitcoin/models.py
@@ -262,6 +262,7 @@ class WalletTransaction(models.Model):
         max_digits=16, 
         decimal_places=8, 
         default=Decimal("0.0"))
+    description = models.CharField(max_length=100, blank=True)
     
     def __unicode__(self):
         if self.from_wallet and self.to_wallet:
@@ -299,7 +300,7 @@ class Wallet(models.Model):
         '''
         return self.receiving_address(fresh_addr=False)
 
-    def send_to_wallet(self, otherWallet, amount):
+    def send_to_wallet(self, otherWallet, amount, description=''):
         if amount>self.total_balance():
             raise Exception(_("Trying to send too much"))
         if self==otherWallet:
@@ -309,7 +310,8 @@ class Wallet(models.Model):
         return WalletTransaction.objects.create(
             amount=amount,
             from_wallet=self,
-            to_wallet=otherWallet)
+            to_wallet=otherWallet,
+            description=description)
     
     def send_to_address(self, address, amount):
         if Decimal(amount)<Decimal(0):

--- a/django_bitcoin/templates/wallet_history.html
+++ b/django_bitcoin/templates/wallet_history.html
@@ -5,13 +5,15 @@
         <th>{% trans "date" %}</th>
         <th>{% trans "type" %}</th>
         <th>{% trans "amount" %}</th>
+        <th>{% trans "description" %}</th>
     </tr>
     {% for addr in wallet.addresses.all %}
     {% if addr.received %}
     <tr>
         <td>{{ addr.created_at }}</td>
-        <td>{% trans "Bitoin deposit" %}</td>
+        <td>{% trans "Bitcoin deposit" %}</td>
         <td>+{{ addr.received }}</td>
+        <td></td>
     </tr>
     {% endif %}
     {% endfor %}
@@ -20,6 +22,7 @@
         <td>{{ t.created_at }}</td>
         <td>{% trans "Wallet receive" %}</td>
         <td>+{{ t.amount }}</td>
+        <td>{{ t.description }}</td>
     </tr>
     {% endfor %}
     {% for t in wallet.sent_transactions.all %}
@@ -36,6 +39,7 @@
             
         {% endif %}</td>
     <td>-{{ t.amount }}</td>
+    <td>{{ t.description }}</td>
     </tr>
     {% endfor %}
 </table>


### PR DESCRIPTION
Transactions between wallets now have an optional "description" field,
with also shows in the wallet transaction log. This is usefull for
maintaining a user-readable transaction log.

Usage example :
     wallet.set_to_wallet(other_wallet, amount, 'reason for payment')
