### PR TITLE
Adding labels to wallets

### DIFF
--- a/django_bitcoin/templates/wallet_history.html
+++ b/django_bitcoin/templates/wallet_history.html
@@ -1,45 +1,56 @@
 {% load i18n %}
+{% load currency_conversions %}
 
 <table>
     <tr>
-        <th>{% trans "date" %}</th>
-        <th>{% trans "type" %}</th>
-        <th>{% trans "amount" %}</th>
-        <th>{% trans "description" %}</th>
+        <th>{% trans "Date" %}</th>
+        <th>{% trans "Type" %}</th>
+        <th>{% trans "To/From" %}</th>
+        <th>{% trans "Amount" %}</th>
+        <th>{% trans "Description" %}</th>
     </tr>
+
     {% for addr in wallet.addresses.all %}
-    {% if addr.received %}
-    <tr>
-        <td>{{ addr.created_at }}</td>
-        <td>{% trans "Bitcoin deposit" %}</td>
-        <td>+{{ addr.received }}</td>
-        <td></td>
-    </tr>
-    {% endif %}
+        {% if addr.received %}
+            <tr>
+                <td>{{ addr.created_at }}</td>
+                <td>{% trans "Credit" %}</td>
+                <td>{{ addr.address|show_addr:'short'|safe}}</td>
+                <td>+{{ addr.received }}</td>
+                <td>{{ t.description }}</td>
+            </tr>
+        {% endif %}
     {% endfor %}
+
     {% for t in wallet.received_transactions.all %}
-    <tr>
-        <td>{{ t.created_at }}</td>
-        <td>{% trans "Wallet receive" %}</td>
-        <td>+{{ t.amount }}</td>
-        <td>{{ t.description }}</td>
-    </tr>
+        <tr>
+            <td>{{ t.created_at }}</td>
+            <td>{% trans "Credit" %}</td>
+            <td>{{ t.from_wallet.label }}</td>
+            <td>+{{ t.amount }}</td>
+            <td>{{ t.description }}</td>
+        </tr>
     {% endfor %}
+
     {% for t in wallet.sent_transactions.all %}
-    <tr>
-        <td>{{ t.created_at }}</td>
-        <td>{% if t.to_wallet %}
-            {% trans "Wallet payment" %}
+        <tr>
+            <td>{{ t.created_at }}</td>
+            <td>{% trans "Debit" %}</td>
+            {% if t.to_wallet %}
+                <td>{{ t.to_wallet.label }}</td>
+                <td>-{{ t.amount }}</td>
+                <td>{{ t.description }}</td>
             {% else %}
-            {% if t.to_address %}
-                {% trans "Bitcoin withdrawal" %}
-            {% else %}
-                {% trans "Fee" %} 
+                {% if t.to_bitcoinaddress %}
+                    <td>{{ t.to_bitcoinaddress|show_addr:'short'|safe}}</td>
+                    <td>-{{ t.amount }}</td>
+                    <td>{{ t.description }}</td>
+                {% else %}
+                    <td>{% trans "The bitcoin network" %}</td>
+                    <td>-{{ t.amount }}</td>
+                    <td>{% trans "Fee paid directly to the bitcoin network" %}</td>
+                {% endif %}
             {% endif %}
-            
-        {% endif %}</td>
-    <td>-{{ t.amount }}</td>
-    <td>{{ t.description }}</td>
-    </tr>
+        </tr>
     {% endfor %}
 </table>

--- a/django_bitcoin/templatetags/currency_conversions.py
+++ b/django_bitcoin/templatetags/currency_conversions.py
@@ -27,6 +27,18 @@ def eur2btc(value):
 def wallet_history(wallet):
     return {'wallet': wallet}
 
+@register.filter
+def show_addr(address, arg):
+    '''
+    Display a bitcoin address with plus the link to its blockexplorer page.
+    '''
+    link ="<a href='http://blockexplorer.com/%s/'>%s</a>"
+    if arg == 'long':
+        return link % (address, address)
+    else:
+        return link % (address, address[:8])
+
+
 @register.inclusion_tag('wallet_tagline.html')
 def wallet_tagline(wallet):
     return {'wallet': wallet, 'balance_usd': btc2usd(wallet.total_balance())}


### PR DESCRIPTION
Now every wallet has an associated label, to show user friendly
transaction logs. When a wallet is created, a label can optionally be
passed, for example:

```
Wallet.objects.create(label='User %s' % user.username)
```

Also made some improvements to the transction log table. It now shows
the labels/addresses that were part of the transactions.
