### PR TITLE
Fix BCAddressField where field is required but there is no value

### DIFF
--- a/django_bitcoin/BCAddressField.py
+++ b/django_bitcoin/BCAddressField.py
@@ -16,7 +16,7 @@ class BCAddressField(forms.CharField):
         super(BCAddressField, self).__init__(*args, **kwargs)
 
     def clean(self, value):
-        if not value and not self.required:
+        if not value or not self.required:
             return None
         value = value.strip()
         if re.match(r"[a-zA-Z1-9]{27,35}$", value) is None:


### PR DESCRIPTION
If the field matches above conditions, validation will raise an AttributeError:

...
File ".../python2.7/site-packages/django/forms/forms.py", line 287, in _clean_fields
    value = field.clean(value)
  File ".../python2.7/site-packages/django_bitcoin/BCAddressField.py", line 21, in clean
    value = value.strip()
AttributeError: 'NoneType' object has no attribute 'strip'
