### PR TITLE
Forwards compatibility to Django 1.6

### DIFF
--- a/django_bitcoin/urls.py
+++ b/django_bitcoin/urls.py
@@ -1,5 +1,8 @@
-from django.conf.urls.defaults import patterns, url
+try:
+    from django.conf.urls import patterns, url
+except ImportError:
+    from django.conf.urls.defaults import patterns, url
 
 urlpatterns = patterns('django_bitcoin.views',
-    url(r'qrcode/(?P<key>.+)$','qrcode_view',name='qrcode'),
+    url(r'^qrcode/(?P<key>.+)$','qrcode_view',name='qrcode'),
 )


### PR DESCRIPTION
Django 1.6 removed `django.conf.urls.defaults`. Try using the new way before falling back to the old (pre-1.4) way.
